### PR TITLE
Retrieve SSN from VMware hosts - tested only on VMware ESXi 5.0 & 5.1

### DIFF
--- a/lib/FusionInventory/Agent/SOAP/VMware/Host.pm
+++ b/lib/FusionInventory/Agent/SOAP/VMware/Host.pm
@@ -46,6 +46,7 @@ sub getBiosInfo {
     my $hardware   = $self->{hash}[0]{hardware};
     my $biosInfo   = $hardware->{biosInfo};
     my $systemInfo = $hardware->{systemInfo};
+    my $ssn;
 
     return unless ref($biosInfo) eq 'HASH';
 
@@ -53,13 +54,22 @@ sub getBiosInfo {
     if (ref($systemInfo->{otherIdentifyingInfo}) eq 'HASH') {
         $identifierValue = $systemInfo->{otherIdentifyingInfo}->{identifierValue};
     }
+    elsif (ref($systemInfo->{otherIdentifyingInfo}) eq 'ARRAY') {
+        foreach (@{$systemInfo->{otherIdentifyingInfo}}) {
+            if ($_->{identifierType}->{key} eq 'ServiceTag') {
+                $ssn = $_->{identifierValue};
+                last;
+            }
+        }
+    }
 
     return {
         BDATE         => $biosInfo->{releaseDate},
         BVERSION      => $biosInfo->{biosVersion},
         SMODEL        => $systemInfo->{model},
         SMANUFACTURER => $systemInfo->{vendor},
-        ASSETTAG      => $identifierValue
+        ASSETTAG      => $identifierValue,
+        SSN           => $ssn
     };
 }
 


### PR DESCRIPTION
Signed-off-by: Jonathan Raffre jonathan.raffre@nekolover.net

This pull request implements retrieve of SSN (ServiceTag for HP / Dell / other hardware) for VMware ESXi 5.0 / 5.1.

Thanks to @trogeat for the bug report !
