### PR TITLE
avoid warnings in resolv()

### DIFF
--- a/lib/FusionInventory/Agent/Tools/Network.pm
+++ b/lib/FusionInventory/Agent/Tools/Network.pm
@@ -135,11 +135,11 @@ sub resolv {
             Socket::GetAddrInfo::NI_NUMERICHOST(),
         );
         # Drop the zone index. Net::IP do not support them
-        $host =~ s/%.*$//;
         if ($error && $logger) {
-            $logger->error("unable to get host `$host' IP address: $error");
+            $logger->error("unable to get hostname of IP address `$result->{addr}': $error");
             next;
         }
+        $host =~ s/%.*$//;
         push @ret, Net::IP->new($host);
     }
 


### PR DESCRIPTION
small fix to avoid the warnings reported in http://forge.fusioninventory.org/issues/2193
