### PR TITLE
[MacOSX] Update CPU.pm

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/MacOS/CPU.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/MacOS/CPU.pm
@@ -53,7 +53,8 @@ sub _getCpus {
     }
     close $handle;
 
-    my $type  = $sysprofile_info->{'Processor Name'} ||
+    my $type  = $sysctl_info->{'machdep.cpu.brand_string'} || 
+                $sysprofile_info->{'Processor Name'} ||
                 $sysprofile_info->{'CPU Type'};
     my $procs = $sysprofile_info->{'Number Of Processors'} ||
                 $sysprofile_info->{'Number Of CPUs'}       ||

--- a/t/tasks/inventory/macos/cpu.t
+++ b/t/tasks/inventory/macos/cpu.t
@@ -17,7 +17,7 @@ my %tests = (
         {
             CORE         => '2',
             MANUFACTURER => 'Intel',
-            NAME         => 'Intel Core 2 Duo',
+            NAME         => 'Intel(R) Core(TM)2 Duo CPU     P7550  @ 2.26GHz',
             THREAD       => 2,
             FAMILYNUMBER => '6',
             MODEL        => '23',


### PR DESCRIPTION
Hi. I'm add discovery CPU type from sysctl. When fusioninventory-agent send data, i'm see only in Computers=>Components=>Name CPU(example: Intel Core i5), but not Name CPU,Type and Frequency(Intel Core i5-4308U @ 2.80Ghz). It's me confused :(
Discover CPU need make from sysctl, because /usr/sbin/system_profiler receives only cpu name. 
My test system:
MacMini, Sierra 10.12.5, fusioninventory-agent 2.3.18
> #system_profiler SPSoftwareDataType
> 
> Hardware:
> 
>     Hardware Overview:
> 
>       Model Name: Mac mini
>       Model Identifier: Macmini7,1
>       Processor Name: Intel Core i5
>       Processor Speed: 2.8 GHz
>       Number of Processors: 1 
> ...

May be my correction help other users.
i'm sorry for my bad English.
Thanks a lot!:)