### PR TITLE
feature: compute SNMPHOSTNAME when missing

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,6 +35,7 @@ netdiscovery/netinventory:
 * Add Panasas PanFS support
 * Add few HP/Compaq serialnumber cases support
 * Fix #605: try 'ip neighbor show' if 'arp' is not available for netdiscovery
+* Set a default hostname, eventually based on serialnumber, when none found
 
 2.4.2 Wed, 03 Oct 2018
 

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -351,9 +351,12 @@ sub _getDevice {
     # SNMPHOSTNAME should be mandatory for server-side import. Many devices
     # badly implemented won't provide any usable hostname when not fully
     # configured. Then it's definitively better to compute one from serial
-    # or set a default one while none is found.
-    $device->{SNMPHOSTNAME} = $device->{SERIAL} ? 'device-'.$device->{SERIAL} : 'noname-device'
-        unless defined($device->{SNMPHOSTNAME});
+    # when one is found.
+    if (!defined($device->{SNMPHOSTNAME}) && $device->{SERIAL}) {
+        my $sn = $device->{SERIAL};
+        $sn =~ s/\s+/_/g;
+        $device->{SNMPHOSTNAME} = 'noname_'.$sn;
+    }
 
     return $device;
 }

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -348,8 +348,10 @@ sub _getDevice {
     # Find ip
     $device->setIp();
 
-    # SNMPHOSTNAME is mandatory for server-side import, compute one from serial
-    # or set a default one for the rare case it is not set
+    # SNMPHOSTNAME should be mandatory for server-side import. Many devices
+    # badly implemented won't provide any usable hostname when not fully
+    # configured. Then it's definitively better to compute one from serial
+    # or set a default one while none is found.
     $device->{SNMPHOSTNAME} = $device->{SERIAL} ? 'device-'.$device->{SERIAL} : 'noname-device'
         unless defined($device->{SNMPHOSTNAME});
 

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -348,6 +348,11 @@ sub _getDevice {
     # Find ip
     $device->setIp();
 
+    # SNMPHOSTNAME is mandatory for server-side import, compute one from serial
+    # or set a default one for the rare case it is not set
+    $device->{SNMPHOSTNAME} = $device->{SERIAL} ? 'device-'.$device->{SERIAL} : 'noname-device'
+        unless defined($device->{SNMPHOSTNAME});
+
     return $device;
 }
 

--- a/t/agent/tools/hardware.t
+++ b/t/agent/tools/hardware.t
@@ -237,10 +237,7 @@ my $snmp1 = FusionInventory::Agent::SNMP::Mock->new(
 my $device1 = getDeviceInfo(snmp => $snmp1);
 cmp_deeply(
     $device1,
-    {
-        DESCRIPTION  => 'foo',
-        SNMPHOSTNAME => 'noname-device',
-    },
+    { DESCRIPTION => 'foo' },
     'getDeviceInfo() with no sysobjectid'
 );
 
@@ -256,7 +253,6 @@ cmp_deeply(
     $device2,
     {
         DESCRIPTION  => 'foo',
-        SNMPHOSTNAME => 'noname-device',
     },
     'getDeviceInfo() with sysobjectid'
 );
@@ -268,7 +264,6 @@ cmp_deeply(
         DESCRIPTION  => 'foo',
         TYPE         => 'NETWORKING',
         MANUFACTURER => 'Nortel',
-        SNMPHOSTNAME => 'noname-device',
     },
     'getDeviceInfo() with sysobjectid'
 );
@@ -285,7 +280,6 @@ cmp_deeply(
         TYPE         => 'NETWORKING',
         MANUFACTURER => 'Qlogic',
         MODEL        => 'SANbox 5602 FC Switch',
-        SNMPHOSTNAME => 'noname-device',
     },
     'getDeviceInfo() with sysobjectid and extmod'
 );

--- a/t/agent/tools/hardware.t
+++ b/t/agent/tools/hardware.t
@@ -237,7 +237,10 @@ my $snmp1 = FusionInventory::Agent::SNMP::Mock->new(
 my $device1 = getDeviceInfo(snmp => $snmp1);
 cmp_deeply(
     $device1,
-    { DESCRIPTION => 'foo' },
+    {
+        DESCRIPTION  => 'foo',
+        SNMPHOSTNAME => 'noname-device',
+    },
     'getDeviceInfo() with no sysobjectid'
 );
 
@@ -253,6 +256,7 @@ cmp_deeply(
     $device2,
     {
         DESCRIPTION  => 'foo',
+        SNMPHOSTNAME => 'noname-device',
     },
     'getDeviceInfo() with sysobjectid'
 );
@@ -264,6 +268,7 @@ cmp_deeply(
         DESCRIPTION  => 'foo',
         TYPE         => 'NETWORKING',
         MANUFACTURER => 'Nortel',
+        SNMPHOSTNAME => 'noname-device',
     },
     'getDeviceInfo() with sysobjectid'
 );
@@ -280,6 +285,7 @@ cmp_deeply(
         TYPE         => 'NETWORKING',
         MANUFACTURER => 'Qlogic',
         MODEL        => 'SANbox 5602 FC Switch',
+        SNMPHOSTNAME => 'noname-device',
     },
     'getDeviceInfo() with sysobjectid and extmod'
 );


### PR DESCRIPTION
Set it first from SERIAL
Finally set it to 'noname-device' if SERIAL is also missing

As generally a constraint rule is set on server-side to have a hostname, setting a default one would help user to have many devices not imported without clear reason. I found a lot of devices in our private snmp walk repository for which SNMPHOSTNAME was not set...

If users don't like the default name, they still can set the hostname on a device to have it updated during next network inventory.