### PR TITLE
feature: reload target when state file has changed

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,8 @@ core:
 * win32: fix a handle leak case when agent was running as service
 * Fix #637: Don't depend on GNU install during "make install" to support
   more Unix systems
+* daemon/service: reload target when the stat file has been updated by
+  another script to use the updated next run timeout
 
 inventory:
 * win32 antivirus support update:

--- a/lib/FusionInventory/Agent/Target.pm
+++ b/lib/FusionInventory/Agent/Target.pm
@@ -90,6 +90,9 @@ sub resetNextRunDate {
 sub getNextRunDate {
     my ($self) = @_;
 
+    # Check if state file has been updated by a third party, like a script run
+    $self->_loadState() if $self->_needToReloadState();
+
     return $self->{nextRunDate};
 }
 
@@ -180,6 +183,12 @@ sub _saveState {
             nextRunDate => $self->{nextRunDate},
         }
     );
+}
+
+sub _needToReloadState {
+    my ($self) = @_;
+
+    return $self->{storage}->modified(name => 'target');
 }
 
 1;


### PR DESCRIPTION
Check modification time of the state file to decide to reload it
as soon as we detect an update.

As a result, after using `/runnow` option with the windows installer, the service will detect the next run timeout is later than expected because the agent was run from a hidden console by the installer.

Also, on unix/linux systems, if a fusioninventory-agent daemon is running and you run manually the agent from an admin console, it will detect the new run timeout.