### PR TITLE
Linux storages support update

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,6 +21,9 @@ inventory:
 * Fix #625: Container UUID is the same than host UUID
 * Fix #624: Skip incomplete battery infos from dmidecode (seen on MacOS)
 * Fix #631: Fix duplicated memory inventory on MacOS
+* linux: fix storage size inventory
+* linux: try to set storage serialnumber from mbr partition id or even
+  PV UUID when not found (hdparm missing or virtual drive)
 
 netdiscovery/netinventory:
 * Add BlueCoat proxy appliance serialnumber support

--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
@@ -92,6 +92,14 @@ sub _getDevices {
         if (!$device->{DISKSIZE} && $device->{TYPE} !~ /^cd/) {
             $device->{DISKSIZE} = getDeviceCapacity(device => '/dev/' . $device->{NAME});
         }
+
+        # In some case, serial can't be defined using hdparm (command missing or virtual disk)
+        # Then we can define a serial searching for few specific identifiers
+        if (!$device->{SERIALNUMBER}) {
+            $params{device} = '/dev/' . $device->{NAME};
+            $device->{SERIALNUMBER} = _getDiskIdentifier(%params) ||
+                _getPVUUID(%params) || "";
+        }
     }
 
     return @devices;
@@ -174,6 +182,41 @@ sub _correctHdparmAvailable {
     # we need at least version 9.15
     return compareVersion($major, $minor, 9, 15);
 
+}
+
+sub _getDiskIdentifier {
+    my (%params) = @_;
+
+    return unless $params{device} && canRun("fdisk");
+
+    # GNU version requires -p flag
+    my $command = getFirstLine(command => 'fdisk -v') =~ '^GNU' ?
+        "fdisk -p -l $params{device}" :
+        "fdisk -l $params{device}"    ;
+
+    my $identifier = getFirstMatch(
+        command => $command,
+        pattern => qr/^Disk identifier:\s*(?:0x)?(\S+)$/i,
+        logger  => $params{logger},
+    );
+
+    return $identifier;
+}
+
+sub _getPVUUID {
+    my (%params) = @_;
+
+    return unless $params{device} && canRun("lvm");
+
+    my $command = "lvm pvdisplay -C -o pv_uuid --noheadings $params{device}" ;
+
+    my $uuid = getFirstMatch(
+        command => $command,
+        pattern => qr/^\s*(\S+)/,
+        logger  => $params{logger},
+    );
+
+    return $uuid;
 }
 
 1;

--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
@@ -83,7 +83,7 @@ sub _getDevices {
             $device->{SERIALNUMBER}
         );
 
-        if (!$device->{MANUFACTURER} or $device->{MANUFACTURER} eq 'ATA') {
+        if (!$device->{MANUFACTURER} || $device->{MANUFACTURER} eq 'ATA') {
             $device->{MANUFACTURER} = getCanonicalManufacturer(
                 $device->{MODEL}
             );

--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
@@ -101,8 +101,8 @@ sub _getDevices {
         # Then we can define a serial searching for few specific identifiers
         if (!$device->{SERIALNUMBER}) {
             $params{device} = '/dev/' . $device->{NAME};
-            $device->{SERIALNUMBER} = _getDiskIdentifier(%params) ||
-                _getPVUUID(%params) || "";
+            my $sn = _getDiskIdentifier(%params) || _getPVUUID(%params);
+            $device->{SERIALNUMBER} = $sn if $sn;
         }
     }
 

--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
@@ -87,6 +87,10 @@ sub _getDevices {
             $device->{MANUFACTURER} = getCanonicalManufacturer(
                 $device->{MODEL}
             );
+        } elsif ($device->{MANUFACTURER} && $device->{MANUFACTURER} =~ /^0x(\w+)$/) {
+            my $vendor = getPCIDeviceVendor(id => lc($1));
+            $device->{MANUFACTURER} = $vendor->{name}
+                if $vendor && $vendor->{name};
         }
 
         if (!$device->{DISKSIZE} && $device->{TYPE} !~ /^cd/) {

--- a/lib/FusionInventory/Agent/Tools/Linux.pm
+++ b/lib/FusionInventory/Agent/Tools/Linux.pm
@@ -240,6 +240,12 @@ sub getDevicesFromProc {
             last;
         }
 
+        # Support disk size from /sys/block
+        my $size_by_sectors = _getValueFromSysProc($logger, $name, 'size');
+        if ($size_by_sectors) {
+            $device->{DISKSIZE} = int($size_by_sectors * 512 / 1_000_000);
+        }
+
         # Check removable capacity as HintAuto via udiskctl while available
         if ($udisksctl && $device->{TYPE} eq 'disk') {
             my $hintauto = getFirstMatch(


### PR DESCRIPTION
* set disk serial number from partition disk identifier or PV UUID when missing
* first read disk size from /sys/block fs
* fix disk manufacturer when found as hexadecimal number