### PR TITLE
Fix lspci output parsing

### DIFF
--- a/lib/FusionInventory/Agent/Tools/Generic.pm
+++ b/lib/FusionInventory/Agent/Tools/Generic.pm
@@ -233,8 +233,8 @@ sub getPCIDevices {
             undef $controller;
         } elsif ($line =~ /^\tKernel driver in use: (\w+)/) {
             $controller->{DRIVER} = $1;
-        } elsif ($line =~ /^\tSubsystem: ([a-f\d]{4}:[a-f\d]{4})/) {
-            $controller->{PCISUBSYSTEMID} = $1;
+        } elsif ($line =~ /^\tSubsystem: ?(.*) \[?([a-f\d]{4}:[a-f\d]{4})\]?/) {
+            $controller->{PCISUBSYSTEMID} = $2;
         }
     }
 

--- a/lib/FusionInventory/Agent/Tools/Generic.pm
+++ b/lib/FusionInventory/Agent/Tools/Generic.pm
@@ -233,8 +233,8 @@ sub getPCIDevices {
             undef $controller;
         } elsif ($line =~ /^\tKernel driver in use: (\w+)/) {
             $controller->{DRIVER} = $1;
-        } elsif ($line =~ /^\tSubsystem: ?(.*) \[?([a-f\d]{4}:[a-f\d]{4})\]?/) {
-            $controller->{PCISUBSYSTEMID} = $2;
+        } elsif ($line =~ /^\tSubsystem: ?.* \[?([a-f\d]{4}:[a-f\d]{4})\]?/) {
+            $controller->{PCISUBSYSTEMID} = $1;
         }
     }
 


### PR DESCRIPTION
PCI subsystem IDs where only detected for the following format

```
00:00.1 ff00: 8086:3591 (rev 04)
        Subsystem: 8086:3591
...
```

, which I only found in lspci versions from CentOS <5.

CentOS >6 and Ubuntu >16.04 have the following format:

```
00:00.0 Host bridge [0600]: Intel Corporation Xeon E5/Core i7 DMI2 [8086:3c00] (rev 07)

        Subsystem: Super Micro Computer Inc Device [15d9:0665]
...
```

I adapted the regex, so that both versions should be detected.
This needs to be tested for the old version: I do not have a working fusioninventory-agent on these machines.