### PR TITLE
feat(win32): add early stderr logging support for service

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,9 @@ core:
   (tested on CentOS 6)
 * win32: don't show service memory usage on OS not supporting GetProcessMemoryInfo
 * Fix #601: Log URL for server target and log path for local target
+* win32: add early stderr logging support for service
+  Just rename "fusioninventory-win32-service.rc.sample" removing ".sample" part
+  to enable this feature. This can be handy to investigate start service failures.
 
 inventory:
 * Fix lspci command subsystem parsing

--- a/bin/fusioninventory-win32-service
+++ b/bin/fusioninventory-win32-service
@@ -13,6 +13,10 @@ use Pod::Usage;
 
 use FusionInventory::Agent::Daemon::Win32;
 
+# Load dedicated .rc file if present. Sample one, if renamed, permits
+# to log stdout and stderr for early debugging purpose
+do __FILE__ . ".rc" if (!@ARGV && -e __FILE__ . ".rc");
+
 Getopt::Long::Configure( "no_ignorecase" );
 
 my %options = ();

--- a/bin/fusioninventory-win32-service.rc.sample
+++ b/bin/fusioninventory-win32-service.rc.sample
@@ -1,0 +1,29 @@
+
+BEGIN {
+    use File::Spec;
+
+    my $logdir = File::Spec->rel2abs( '../../../logs', __FILE__ );
+    #~ $logdir = "c:/temp";
+
+    if (-d $logdir) {
+        open(STDERR, ">$logdir/stderr.txt")
+            or die "Can't redirect STDERR to stderr.txt: $!";
+        open(STDOUT, ">$logdir/stdout.txt")
+            or die "Can't redirect STDOUT to stdout.txt: $!";
+
+        select STDERR;
+        $| = 1;
+        select STDOUT;
+        $| = 1;
+
+        print STDERR localtime().": BEGIN stderr.txt\n";
+        print localtime().": BEGIN stdout.txt\n";
+    } else {
+        print STDERR localtime().": Logging folder $logdir is missing\n";
+    }
+}
+
+END {
+    print STDERR localtime().": END stderr.txt\n";
+    print localtime().": END stdout.txt\n";
+}


### PR DESCRIPTION
It seems we still have few issues during win32 service start.

The only way to fully investigate such issues is to catch STDERR during service start.

This PR introduces a way to quickly enable service STDERR catching in a dedicated file:
Just rename "fusioninventory-win32-service.rc.sample" by removing the ".sample" part.

By default, you need a `logs` folder in the installation folder and will find `stderr.txt` and `stdout.txt` file after starting a service.