### PR TITLE
Add Tagged VLAN, work at least with HPE Switch

### DIFF
--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1437,7 +1437,7 @@ sub _getVlans {
 
                 next if ($bUntagged eq '' && $bEgress eq '');
 
-                foreach my $port_id (keys %{$ports}){
+                foreach my $port_id (keys %{$ports}) {
                     my $isUntagged = ($port_id-1 <= length($bUntagged)) ? substr($bUntagged, $port_id-1, 1) : '0';
                     my $isTagged = ($isUntagged eq '0' && ($port_id-1 <= length($bEgress))) ? substr($bEgress, $port_id-1, 1) : '0';
                     push @{$results->{$port_id}}, {
@@ -1448,12 +1448,12 @@ sub _getVlans {
                 }
             }
         }
-    }else{
+    } else {
         # For other switches, we use another methods
         # used for Alcatel-Lucent and ExtremNetworks (and perhaps others)
         my $vlanIdName = $snmp->walk('.1.0.8802.1.1.2.1.5.32962.1.2.3.1.2');
         my $portLink = $snmp->walk('.1.0.8802.1.1.2.1.3.7.1.3');
-        if($vlanIdName && $portLink){
+        if ($vlanIdName && $portLink) {
             foreach my $suffix (sort keys %{$vlanIdName}) {
                 my ($port, $vlan) = split(/\./, $suffix);
                 if ($portLink->{$port}) {
@@ -1472,7 +1472,7 @@ sub _getVlans {
         } else {
             # A last method
             my $vlanId = $snmp->walk('.1.0.8802.1.1.2.1.5.32962.1.2.1.1.1');
-            if($vlanId){
+            if ($vlanId) {
                 foreach my $port (sort keys %{$vlanId}) {
                     push @{$results->{$port}}, {
                         NUMBER => $vlanId->{$port},

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1412,8 +1412,8 @@ sub _getVlans {
     my $dot1qVlanCurrentUntaggedPorts = $snmp->walk('.1.3.6.1.2.1.17.7.1.4.2.1.5');
 
     if($dot1qVlanStaticRowStatus and $dot1qVlanStaticRowStatus and $dot1qVlanCurrentEgressPorts and $dot1qVlanCurrentUntaggedPorts){
-        while (my ($vlan_id, $status) = each %{$dot1qVlanStaticRowStatus}) {
-            if($status eq 1) {
+        foreach my $vlan_id (sort keys %{$dot1qVlanStaticRowStatus}) {
+            if($dot1qVlanStaticRowStatus->{$vlan_id} eq 1) {
                 my $name = $dot1qVlanStaticName->{$vlan_id};
 
                 my $suffix = defined($dot1qVlanCurrentEgressPorts->{$vlan_id}) ? $vlan_id : ("0.".$vlan_id);

--- a/lib/FusionInventory/Agent/Tools/Hardware.pm
+++ b/lib/FusionInventory/Agent/Tools/Hardware.pm
@@ -1411,9 +1411,9 @@ sub _getVlans {
     my $dot1qVlanCurrentEgressPorts = $snmp->walk('.1.3.6.1.2.1.17.7.1.4.2.1.4');
     my $dot1qVlanCurrentUntaggedPorts = $snmp->walk('.1.3.6.1.2.1.17.7.1.4.2.1.5');
 
-    if($dot1qVlanStaticRowStatus and $dot1qVlanStaticRowStatus and $dot1qVlanCurrentEgressPorts and $dot1qVlanCurrentUntaggedPorts){
+    if ($dot1qVlanStaticRowStatus && $dot1qVlanStaticRowStatus && $dot1qVlanCurrentEgressPorts && $dot1qVlanCurrentUntaggedPorts) {
         foreach my $vlan_id (sort keys %{$dot1qVlanStaticRowStatus}) {
-            if($dot1qVlanStaticRowStatus->{$vlan_id} eq 1) {
+            if ($dot1qVlanStaticRowStatus->{$vlan_id} eq 1) {
                 my $name = $dot1qVlanStaticName->{$vlan_id};
 
                 my $suffix = defined($dot1qVlanCurrentEgressPorts->{$vlan_id}) ? $vlan_id : ("0.".$vlan_id);
@@ -1421,30 +1421,30 @@ sub _getVlans {
 
                 # Tagged & Untagged VLAN
                 my $bEgress = '';
-                if(Math::BigInt->from_hex($dot1qVlanCurrentEgressPorts->{$suffix}) ne Math::BigInt->bnan()){
-                    for( my $i=2; $i< length($dot1qVlanCurrentEgressPorts->{$suffix}); $i++){
+                if (isStringHexadecimal($dot1qVlanCurrentEgressPorts->{$suffix})) {
+                    for (my $i=2; $i< length($dot1qVlanCurrentEgressPorts->{$suffix}); $i++) {
                         $bEgress .= sprintf('%04b', hex(substr($dot1qVlanCurrentEgressPorts->{$suffix}, $i, 1)));
                     }
                 }
 
-                # Untagged VLAN
+                # Untagged VLAN 
                 my $bUntagged = '';
-                if(Math::BigInt->from_hex($dot1qVlanCurrentUntaggedPorts->{$suffix}) ne Math::BigInt->bnan()){
-                    for( my $i=2; $i< length($dot1qVlanCurrentUntaggedPorts->{$suffix}); $i++){
+                if (isStringHexadecimal($dot1qVlanCurrentUntaggedPorts->{$suffix})) {
+                    for (my $i=2; $i< length($dot1qVlanCurrentUntaggedPorts->{$suffix}); $i++) {
                         $bUntagged .= sprintf('%04b', hex(substr($dot1qVlanCurrentUntaggedPorts->{$suffix}, $i, 1)));
                     }
                 }
 
-                next if($bUntagged eq '' and $bEgress eq '');
+                next if ($bUntagged eq '' && $bEgress eq '');
 
                 foreach my $port_id (keys %{$ports}){
                     my $isUntagged = ($port_id-1 <= length($bUntagged)) ? substr($bUntagged, $port_id-1, 1) : '0';
-                    my $isTagged = ($isUntagged eq '0' and ($port_id-1 <= length($bEgress))) ? substr($bEgress, $port_id-1, 1) : '0';
+                    my $isTagged = ($isUntagged eq '0' && ($port_id-1 <= length($bEgress))) ? substr($bEgress, $port_id-1, 1) : '0';
                     push @{$results->{$port_id}}, {
                         NUMBER  => $vlan_id,
                         NAME    => $name,
                         TAGGED  => $isTagged
-                    } if $isTagged or $isUntagged;
+                    } if $isTagged || $isUntagged;
                 }
             }
         }

--- a/lib/FusionInventory/Agent/Tools/SNMP.pm
+++ b/lib/FusionInventory/Agent/Tools/SNMP.pm
@@ -190,4 +190,4 @@ return compiled regexp to match given oid.
 
 =head2 isStringHexadecimal($value)
 
-return true if value is an string hexadecimal (start with 0x).
+return true if value is a string hexadecimal (start with 0x).

--- a/lib/FusionInventory/Agent/Tools/SNMP.pm
+++ b/lib/FusionInventory/Agent/Tools/SNMP.pm
@@ -15,6 +15,7 @@ our @EXPORT = qw(
     getCanonicalCount
     isInteger
     getRegexpOidMatch
+    isStringHexadecimal
 );
 
 sub getCanonicalSerialNumber {
@@ -144,6 +145,12 @@ sub getRegexpOidMatch {
     return qr/^$match/;
 }
 
+sub isStringHexadecimal {
+    my ($value) = @_;
+
+    return $value =~ /^0x[0-9a-fA-F]+$/;
+}
+
 1;
 __END__
 
@@ -180,3 +187,7 @@ return true if value is an integer.
 =head2 getRegexpOidMatch($oid)
 
 return compiled regexp to match given oid.
+
+=head2 isStringHexadecimal($value)
+
+return true if value is an string hexadecimal (start with 0x).

--- a/resources/walks/sample4.result
+++ b/resources/walks/sample4.result
@@ -70,12 +70,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:ff</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -106,12 +100,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:fe</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -142,12 +130,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:fd</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -178,12 +160,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:fc</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -214,12 +190,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:fb</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -250,12 +220,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:fa</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -286,12 +250,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:f9</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -322,12 +280,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:f8</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -358,12 +310,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:f7</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -394,12 +340,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:f6</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <IFINERRORS>0</IFINERRORS>
@@ -419,8 +359,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -442,8 +383,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -476,12 +418,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:f3</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <IFINERRORS>0</IFINERRORS>
@@ -501,8 +437,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -535,12 +472,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:f1</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <IFINERRORS>0</IFINERRORS>
@@ -560,8 +491,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -594,12 +526,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:ef</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <IFINERRORS>0</IFINERRORS>
@@ -619,8 +545,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -653,12 +580,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:ed</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <IFINERRORS>0</IFINERRORS>
@@ -678,8 +599,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -712,12 +634,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:eb</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -748,12 +664,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:ea</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -784,12 +694,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:e9</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -820,12 +724,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:e8</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -856,12 +754,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:e7</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -892,12 +784,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:e6</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -928,12 +814,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:e5</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -964,12 +844,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:e4</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -1000,12 +874,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:e3</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <IFDESCR>B6</IFDESCR>
@@ -1024,12 +892,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:e2</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -1060,12 +922,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:e1</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -1096,12 +952,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:e0</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -1132,12 +982,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:df</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -1168,12 +1012,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:de</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <IFINERRORS>0</IFINERRORS>
@@ -1193,8 +1031,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -1216,8 +1055,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -1250,12 +1090,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:db</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <IFINERRORS>0</IFINERRORS>
@@ -1275,8 +1109,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -1309,12 +1144,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:d9</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <IFINERRORS>0</IFINERRORS>
@@ -1334,8 +1163,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -1368,12 +1198,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:d7</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <IFINERRORS>0</IFINERRORS>
@@ -1393,8 +1217,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -1427,12 +1252,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:d5</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <IFINERRORS>0</IFINERRORS>
@@ -1452,8 +1271,9 @@
           <TRUNK>0</TRUNK>
           <VLANS>
             <VLAN>
-              <NAME>VLAN 1</NAME>
+              <NAME>DEFAULT_VLAN</NAME>
               <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
             </VLAN>
           </VLANS>
         </PORT>
@@ -1486,12 +1306,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:d3</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -1522,12 +1336,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:d2</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -1558,12 +1366,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:d1</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <CONNECTIONS>
@@ -1594,12 +1396,6 @@
           <IFTYPE>6</IFTYPE>
           <MAC>00:18:71:c1:f0:d0</MAC>
           <TRUNK>0</TRUNK>
-          <VLANS>
-            <VLAN>
-              <NAME>VLAN 1</NAME>
-              <NUMBER>1</NUMBER>
-            </VLAN>
-          </VLANS>
         </PORT>
         <PORT>
           <AGGREGATE>
@@ -1639,6 +1435,238 @@
           <IFSTATUS>1</IFSTATUS>
           <IFTYPE>161</IFTYPE>
           <MAC>00:18:71:c1:e0:00</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>DEFAULT_VLAN</NAME>
+              <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VOIP_ASTERISK</NAME>
+              <NUMBER>13</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ227</NAME>
+              <NUMBER>14</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE_IP_RIHDA</NAME>
+              <NUMBER>149</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO-CSS</NAME>
+              <NUMBER>15</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RENATER</NAME>
+              <NUMBER>150</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA</NAME>
+              <NUMBER>152</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-VLAN-LIBRE</NAME>
+              <NUMBER>153</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-INTERCO-FOUNDRY</NAME>
+              <NUMBER>154</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ</NAME>
+              <NUMBER>155</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-Libre_Service</NAME>
+              <NUMBER>156</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-PEDA</NAME>
+              <NUMBER>157</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA2</NAME>
+              <NUMBER>158</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-PUG-DRRT</NAME>
+              <NUMBER>159</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVEUR-CSS</NAME>
+              <NUMBER>16</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ToIP_RIHDA</NAME>
+              <NUMBER>160</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>LIBR_SERVICE</NAME>
+              <NUMBER>162</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTER_EQUANT_RECTORAT</NAME>
+              <NUMBER>17</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_RIHDA</NAME>
+              <NUMBER>170</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_POLY</NAME>
+              <NUMBER>171</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_CEPE</NAME>
+              <NUMBER>172</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INT_EQUANT_ETABLISSEMENTS</NAME>
+              <NUMBER>18</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>video_RIHDA</NAME>
+              <NUMBER>180</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>postesIP_RIHDA</NAME>
+              <NUMBER>190</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ADMIN_RESEAU</NAME>
+              <NUMBER>196</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVERS</NAME>
+              <NUMBER>2</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>PERIPHERIQUES</NAME>
+              <NUMBER>201</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_NVEAU_BAT</NAME>
+              <NUMBER>202</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_FORMATION</NAME>
+              <NUMBER>204</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_CATI</NAME>
+              <NUMBER>205</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_INVITES</NAME>
+              <NUMBER>214</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_SYST_RESEAUX</NAME>
+              <NUMBER>215</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_HD</NAME>
+              <NUMBER>22</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ZONE_PUBLIQUE</NAME>
+              <NUMBER>3</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RESEAU_DRRT-PUG</NAME>
+              <NUMBER>30</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE-TEST</NAME>
+              <NUMBER>3000</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-APPLI</NAME>
+              <NUMBER>3002</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-AGRIATE</NAME>
+              <NUMBER>3006</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-ETAB</NAME>
+              <NUMBER>3007</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO_RACINE_API</NAME>
+              <NUMBER>4</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VLAN401</NAME>
+              <NUMBER>401</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>wifi_recteur</NAME>
+              <NUMBER>402</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_ELGG</NAME>
+              <NUMBER>403</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ</NAME>
+              <NUMBER>5</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>AGRIATES</NAME>
+              <NUMBER>6</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ACCUEIL_ETABLISSEMENTS</NAME>
+              <NUMBER>7</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+          </VLANS>
         </PORT>
         <PORT>
           <AGGREGATE>
@@ -1681,6 +1709,218 @@
           <IFSTATUS>1</IFSTATUS>
           <IFTYPE>161</IFTYPE>
           <MAC>00:18:71:c1:e0:00</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>DEFAULT_VLAN</NAME>
+              <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VOIP_ASTERISK</NAME>
+              <NUMBER>13</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ227</NAME>
+              <NUMBER>14</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE_IP_RIHDA</NAME>
+              <NUMBER>149</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO-CSS</NAME>
+              <NUMBER>15</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RENATER</NAME>
+              <NUMBER>150</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA</NAME>
+              <NUMBER>152</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-VLAN-LIBRE</NAME>
+              <NUMBER>153</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-INTERCO-FOUNDRY</NAME>
+              <NUMBER>154</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ</NAME>
+              <NUMBER>155</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-Libre_Service</NAME>
+              <NUMBER>156</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-PEDA</NAME>
+              <NUMBER>157</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA2</NAME>
+              <NUMBER>158</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-PUG-DRRT</NAME>
+              <NUMBER>159</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVEUR-CSS</NAME>
+              <NUMBER>16</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ToIP_RIHDA</NAME>
+              <NUMBER>160</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>LIBR_SERVICE</NAME>
+              <NUMBER>162</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTER_EQUANT_RECTORAT</NAME>
+              <NUMBER>17</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_RIHDA</NAME>
+              <NUMBER>170</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_POLY</NAME>
+              <NUMBER>171</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_CEPE</NAME>
+              <NUMBER>172</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INT_EQUANT_ETABLISSEMENTS</NAME>
+              <NUMBER>18</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>video_RIHDA</NAME>
+              <NUMBER>180</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>postesIP_RIHDA</NAME>
+              <NUMBER>190</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ADMIN_RESEAU</NAME>
+              <NUMBER>196</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVERS</NAME>
+              <NUMBER>2</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>PERIPHERIQUES</NAME>
+              <NUMBER>201</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_NVEAU_BAT</NAME>
+              <NUMBER>202</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_FORMATION</NAME>
+              <NUMBER>204</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_CATI</NAME>
+              <NUMBER>205</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_INVITES</NAME>
+              <NUMBER>214</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_SYST_RESEAUX</NAME>
+              <NUMBER>215</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_HD</NAME>
+              <NUMBER>22</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ZONE_PUBLIQUE</NAME>
+              <NUMBER>3</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RESEAU_DRRT-PUG</NAME>
+              <NUMBER>30</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO_RACINE_API</NAME>
+              <NUMBER>4</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VLAN401</NAME>
+              <NUMBER>401</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>wifi_recteur</NAME>
+              <NUMBER>402</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_ELGG</NAME>
+              <NUMBER>403</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ</NAME>
+              <NUMBER>5</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>AGRIATES</NAME>
+              <NUMBER>6</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ACCUEIL_ETABLISSEMENTS</NAME>
+              <NUMBER>7</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+          </VLANS>
         </PORT>
         <PORT>
           <AGGREGATE>
@@ -1780,6 +2020,218 @@
           <IFSTATUS>1</IFSTATUS>
           <IFTYPE>161</IFTYPE>
           <MAC>00:18:71:c1:e0:00</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>DEFAULT_VLAN</NAME>
+              <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VOIP_ASTERISK</NAME>
+              <NUMBER>13</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ227</NAME>
+              <NUMBER>14</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE_IP_RIHDA</NAME>
+              <NUMBER>149</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO-CSS</NAME>
+              <NUMBER>15</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RENATER</NAME>
+              <NUMBER>150</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA</NAME>
+              <NUMBER>152</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-VLAN-LIBRE</NAME>
+              <NUMBER>153</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-INTERCO-FOUNDRY</NAME>
+              <NUMBER>154</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ</NAME>
+              <NUMBER>155</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-Libre_Service</NAME>
+              <NUMBER>156</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-PEDA</NAME>
+              <NUMBER>157</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA2</NAME>
+              <NUMBER>158</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-PUG-DRRT</NAME>
+              <NUMBER>159</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVEUR-CSS</NAME>
+              <NUMBER>16</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ToIP_RIHDA</NAME>
+              <NUMBER>160</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>LIBR_SERVICE</NAME>
+              <NUMBER>162</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTER_EQUANT_RECTORAT</NAME>
+              <NUMBER>17</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_RIHDA</NAME>
+              <NUMBER>170</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_POLY</NAME>
+              <NUMBER>171</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_CEPE</NAME>
+              <NUMBER>172</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INT_EQUANT_ETABLISSEMENTS</NAME>
+              <NUMBER>18</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>video_RIHDA</NAME>
+              <NUMBER>180</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>postesIP_RIHDA</NAME>
+              <NUMBER>190</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ADMIN_RESEAU</NAME>
+              <NUMBER>196</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVERS</NAME>
+              <NUMBER>2</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>PERIPHERIQUES</NAME>
+              <NUMBER>201</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_NVEAU_BAT</NAME>
+              <NUMBER>202</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_FORMATION</NAME>
+              <NUMBER>204</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_CATI</NAME>
+              <NUMBER>205</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_INVITES</NAME>
+              <NUMBER>214</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_SYST_RESEAUX</NAME>
+              <NUMBER>215</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_HD</NAME>
+              <NUMBER>22</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ZONE_PUBLIQUE</NAME>
+              <NUMBER>3</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RESEAU_DRRT-PUG</NAME>
+              <NUMBER>30</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO_RACINE_API</NAME>
+              <NUMBER>4</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VLAN401</NAME>
+              <NUMBER>401</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>wifi_recteur</NAME>
+              <NUMBER>402</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_ELGG</NAME>
+              <NUMBER>403</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ</NAME>
+              <NUMBER>5</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>AGRIATES</NAME>
+              <NUMBER>6</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ACCUEIL_ETABLISSEMENTS</NAME>
+              <NUMBER>7</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+          </VLANS>
         </PORT>
         <PORT>
           <AGGREGATE>
@@ -1842,6 +2294,218 @@
           <IFSTATUS>1</IFSTATUS>
           <IFTYPE>161</IFTYPE>
           <MAC>00:18:71:c1:e0:00</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>DEFAULT_VLAN</NAME>
+              <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VOIP_ASTERISK</NAME>
+              <NUMBER>13</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ227</NAME>
+              <NUMBER>14</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE_IP_RIHDA</NAME>
+              <NUMBER>149</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO-CSS</NAME>
+              <NUMBER>15</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RENATER</NAME>
+              <NUMBER>150</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA</NAME>
+              <NUMBER>152</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-VLAN-LIBRE</NAME>
+              <NUMBER>153</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-INTERCO-FOUNDRY</NAME>
+              <NUMBER>154</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ</NAME>
+              <NUMBER>155</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-Libre_Service</NAME>
+              <NUMBER>156</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-PEDA</NAME>
+              <NUMBER>157</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA2</NAME>
+              <NUMBER>158</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-PUG-DRRT</NAME>
+              <NUMBER>159</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVEUR-CSS</NAME>
+              <NUMBER>16</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ToIP_RIHDA</NAME>
+              <NUMBER>160</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>LIBR_SERVICE</NAME>
+              <NUMBER>162</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTER_EQUANT_RECTORAT</NAME>
+              <NUMBER>17</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_RIHDA</NAME>
+              <NUMBER>170</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_POLY</NAME>
+              <NUMBER>171</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_CEPE</NAME>
+              <NUMBER>172</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INT_EQUANT_ETABLISSEMENTS</NAME>
+              <NUMBER>18</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>video_RIHDA</NAME>
+              <NUMBER>180</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>postesIP_RIHDA</NAME>
+              <NUMBER>190</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ADMIN_RESEAU</NAME>
+              <NUMBER>196</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVERS</NAME>
+              <NUMBER>2</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>PERIPHERIQUES</NAME>
+              <NUMBER>201</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_NVEAU_BAT</NAME>
+              <NUMBER>202</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_FORMATION</NAME>
+              <NUMBER>204</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_CATI</NAME>
+              <NUMBER>205</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_INVITES</NAME>
+              <NUMBER>214</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_SYST_RESEAUX</NAME>
+              <NUMBER>215</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_HD</NAME>
+              <NUMBER>22</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ZONE_PUBLIQUE</NAME>
+              <NUMBER>3</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RESEAU_DRRT-PUG</NAME>
+              <NUMBER>30</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO_RACINE_API</NAME>
+              <NUMBER>4</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VLAN401</NAME>
+              <NUMBER>401</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>wifi_recteur</NAME>
+              <NUMBER>402</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_ELGG</NAME>
+              <NUMBER>403</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ</NAME>
+              <NUMBER>5</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>AGRIATES</NAME>
+              <NUMBER>6</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ACCUEIL_ETABLISSEMENTS</NAME>
+              <NUMBER>7</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+          </VLANS>
         </PORT>
         <PORT>
           <AGGREGATE>
@@ -1899,6 +2563,218 @@
           <IFSTATUS>1</IFSTATUS>
           <IFTYPE>161</IFTYPE>
           <MAC>00:18:71:c1:e0:00</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>DEFAULT_VLAN</NAME>
+              <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VOIP_ASTERISK</NAME>
+              <NUMBER>13</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ227</NAME>
+              <NUMBER>14</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE_IP_RIHDA</NAME>
+              <NUMBER>149</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO-CSS</NAME>
+              <NUMBER>15</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RENATER</NAME>
+              <NUMBER>150</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA</NAME>
+              <NUMBER>152</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-VLAN-LIBRE</NAME>
+              <NUMBER>153</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-INTERCO-FOUNDRY</NAME>
+              <NUMBER>154</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ</NAME>
+              <NUMBER>155</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-Libre_Service</NAME>
+              <NUMBER>156</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-PEDA</NAME>
+              <NUMBER>157</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA2</NAME>
+              <NUMBER>158</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-PUG-DRRT</NAME>
+              <NUMBER>159</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVEUR-CSS</NAME>
+              <NUMBER>16</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ToIP_RIHDA</NAME>
+              <NUMBER>160</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>LIBR_SERVICE</NAME>
+              <NUMBER>162</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTER_EQUANT_RECTORAT</NAME>
+              <NUMBER>17</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_RIHDA</NAME>
+              <NUMBER>170</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_POLY</NAME>
+              <NUMBER>171</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_CEPE</NAME>
+              <NUMBER>172</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INT_EQUANT_ETABLISSEMENTS</NAME>
+              <NUMBER>18</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>video_RIHDA</NAME>
+              <NUMBER>180</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>postesIP_RIHDA</NAME>
+              <NUMBER>190</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ADMIN_RESEAU</NAME>
+              <NUMBER>196</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVERS</NAME>
+              <NUMBER>2</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>PERIPHERIQUES</NAME>
+              <NUMBER>201</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_NVEAU_BAT</NAME>
+              <NUMBER>202</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_FORMATION</NAME>
+              <NUMBER>204</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_CATI</NAME>
+              <NUMBER>205</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_INVITES</NAME>
+              <NUMBER>214</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_SYST_RESEAUX</NAME>
+              <NUMBER>215</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_HD</NAME>
+              <NUMBER>22</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ZONE_PUBLIQUE</NAME>
+              <NUMBER>3</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RESEAU_DRRT-PUG</NAME>
+              <NUMBER>30</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO_RACINE_API</NAME>
+              <NUMBER>4</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VLAN401</NAME>
+              <NUMBER>401</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>wifi_recteur</NAME>
+              <NUMBER>402</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_ELGG</NAME>
+              <NUMBER>403</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ</NAME>
+              <NUMBER>5</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>AGRIATES</NAME>
+              <NUMBER>6</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ACCUEIL_ETABLISSEMENTS</NAME>
+              <NUMBER>7</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+          </VLANS>
         </PORT>
         <PORT>
           <AGGREGATE>
@@ -1934,6 +2810,238 @@
           <IFSTATUS>1</IFSTATUS>
           <IFTYPE>161</IFTYPE>
           <MAC>00:18:71:c1:e0:00</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>DEFAULT_VLAN</NAME>
+              <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VOIP_ASTERISK</NAME>
+              <NUMBER>13</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ227</NAME>
+              <NUMBER>14</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE_IP_RIHDA</NAME>
+              <NUMBER>149</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO-CSS</NAME>
+              <NUMBER>15</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RENATER</NAME>
+              <NUMBER>150</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA</NAME>
+              <NUMBER>152</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-VLAN-LIBRE</NAME>
+              <NUMBER>153</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-INTERCO-FOUNDRY</NAME>
+              <NUMBER>154</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ</NAME>
+              <NUMBER>155</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-Libre_Service</NAME>
+              <NUMBER>156</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-PEDA</NAME>
+              <NUMBER>157</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA2</NAME>
+              <NUMBER>158</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-PUG-DRRT</NAME>
+              <NUMBER>159</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVEUR-CSS</NAME>
+              <NUMBER>16</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ToIP_RIHDA</NAME>
+              <NUMBER>160</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>LIBR_SERVICE</NAME>
+              <NUMBER>162</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTER_EQUANT_RECTORAT</NAME>
+              <NUMBER>17</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_RIHDA</NAME>
+              <NUMBER>170</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_POLY</NAME>
+              <NUMBER>171</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_CEPE</NAME>
+              <NUMBER>172</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INT_EQUANT_ETABLISSEMENTS</NAME>
+              <NUMBER>18</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>video_RIHDA</NAME>
+              <NUMBER>180</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>postesIP_RIHDA</NAME>
+              <NUMBER>190</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ADMIN_RESEAU</NAME>
+              <NUMBER>196</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVERS</NAME>
+              <NUMBER>2</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>PERIPHERIQUES</NAME>
+              <NUMBER>201</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_NVEAU_BAT</NAME>
+              <NUMBER>202</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_FORMATION</NAME>
+              <NUMBER>204</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_CATI</NAME>
+              <NUMBER>205</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_INVITES</NAME>
+              <NUMBER>214</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_SYST_RESEAUX</NAME>
+              <NUMBER>215</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_HD</NAME>
+              <NUMBER>22</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ZONE_PUBLIQUE</NAME>
+              <NUMBER>3</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RESEAU_DRRT-PUG</NAME>
+              <NUMBER>30</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE-TEST</NAME>
+              <NUMBER>3000</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-APPLI</NAME>
+              <NUMBER>3002</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-AGRIATE</NAME>
+              <NUMBER>3006</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-ETAB</NAME>
+              <NUMBER>3007</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO_RACINE_API</NAME>
+              <NUMBER>4</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VLAN401</NAME>
+              <NUMBER>401</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>wifi_recteur</NAME>
+              <NUMBER>402</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_ELGG</NAME>
+              <NUMBER>403</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ</NAME>
+              <NUMBER>5</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>AGRIATES</NAME>
+              <NUMBER>6</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ACCUEIL_ETABLISSEMENTS</NAME>
+              <NUMBER>7</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+          </VLANS>
         </PORT>
         <PORT>
           <AGGREGATE>
@@ -1967,6 +3075,238 @@
           <IFSTATUS>1</IFSTATUS>
           <IFTYPE>161</IFTYPE>
           <MAC>00:18:71:c1:e0:00</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>DEFAULT_VLAN</NAME>
+              <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VOIP_ASTERISK</NAME>
+              <NUMBER>13</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ227</NAME>
+              <NUMBER>14</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE_IP_RIHDA</NAME>
+              <NUMBER>149</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO-CSS</NAME>
+              <NUMBER>15</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RENATER</NAME>
+              <NUMBER>150</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA</NAME>
+              <NUMBER>152</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-VLAN-LIBRE</NAME>
+              <NUMBER>153</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-INTERCO-FOUNDRY</NAME>
+              <NUMBER>154</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ</NAME>
+              <NUMBER>155</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-Libre_Service</NAME>
+              <NUMBER>156</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-PEDA</NAME>
+              <NUMBER>157</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA2</NAME>
+              <NUMBER>158</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-PUG-DRRT</NAME>
+              <NUMBER>159</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVEUR-CSS</NAME>
+              <NUMBER>16</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ToIP_RIHDA</NAME>
+              <NUMBER>160</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>LIBR_SERVICE</NAME>
+              <NUMBER>162</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTER_EQUANT_RECTORAT</NAME>
+              <NUMBER>17</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_RIHDA</NAME>
+              <NUMBER>170</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_POLY</NAME>
+              <NUMBER>171</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_CEPE</NAME>
+              <NUMBER>172</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INT_EQUANT_ETABLISSEMENTS</NAME>
+              <NUMBER>18</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>video_RIHDA</NAME>
+              <NUMBER>180</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>postesIP_RIHDA</NAME>
+              <NUMBER>190</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ADMIN_RESEAU</NAME>
+              <NUMBER>196</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVERS</NAME>
+              <NUMBER>2</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>PERIPHERIQUES</NAME>
+              <NUMBER>201</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_NVEAU_BAT</NAME>
+              <NUMBER>202</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_FORMATION</NAME>
+              <NUMBER>204</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_CATI</NAME>
+              <NUMBER>205</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_INVITES</NAME>
+              <NUMBER>214</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_SYST_RESEAUX</NAME>
+              <NUMBER>215</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_HD</NAME>
+              <NUMBER>22</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ZONE_PUBLIQUE</NAME>
+              <NUMBER>3</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RESEAU_DRRT-PUG</NAME>
+              <NUMBER>30</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE-TEST</NAME>
+              <NUMBER>3000</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-APPLI</NAME>
+              <NUMBER>3002</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-AGRIATE</NAME>
+              <NUMBER>3006</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-ETAB</NAME>
+              <NUMBER>3007</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO_RACINE_API</NAME>
+              <NUMBER>4</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VLAN401</NAME>
+              <NUMBER>401</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>wifi_recteur</NAME>
+              <NUMBER>402</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_ELGG</NAME>
+              <NUMBER>403</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ</NAME>
+              <NUMBER>5</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>AGRIATES</NAME>
+              <NUMBER>6</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ACCUEIL_ETABLISSEMENTS</NAME>
+              <NUMBER>7</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+          </VLANS>
         </PORT>
         <PORT>
           <AGGREGATE>
@@ -2007,6 +3347,238 @@
           <IFSTATUS>1</IFSTATUS>
           <IFTYPE>161</IFTYPE>
           <MAC>00:18:71:c1:e0:00</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>DEFAULT_VLAN</NAME>
+              <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VOIP_ASTERISK</NAME>
+              <NUMBER>13</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ227</NAME>
+              <NUMBER>14</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE_IP_RIHDA</NAME>
+              <NUMBER>149</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO-CSS</NAME>
+              <NUMBER>15</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RENATER</NAME>
+              <NUMBER>150</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA</NAME>
+              <NUMBER>152</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-VLAN-LIBRE</NAME>
+              <NUMBER>153</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-INTERCO-FOUNDRY</NAME>
+              <NUMBER>154</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ</NAME>
+              <NUMBER>155</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-Libre_Service</NAME>
+              <NUMBER>156</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-PEDA</NAME>
+              <NUMBER>157</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA2</NAME>
+              <NUMBER>158</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-PUG-DRRT</NAME>
+              <NUMBER>159</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVEUR-CSS</NAME>
+              <NUMBER>16</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ToIP_RIHDA</NAME>
+              <NUMBER>160</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>LIBR_SERVICE</NAME>
+              <NUMBER>162</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTER_EQUANT_RECTORAT</NAME>
+              <NUMBER>17</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_RIHDA</NAME>
+              <NUMBER>170</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_POLY</NAME>
+              <NUMBER>171</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_CEPE</NAME>
+              <NUMBER>172</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INT_EQUANT_ETABLISSEMENTS</NAME>
+              <NUMBER>18</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>video_RIHDA</NAME>
+              <NUMBER>180</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>postesIP_RIHDA</NAME>
+              <NUMBER>190</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ADMIN_RESEAU</NAME>
+              <NUMBER>196</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVERS</NAME>
+              <NUMBER>2</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>PERIPHERIQUES</NAME>
+              <NUMBER>201</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_NVEAU_BAT</NAME>
+              <NUMBER>202</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_FORMATION</NAME>
+              <NUMBER>204</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_CATI</NAME>
+              <NUMBER>205</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_INVITES</NAME>
+              <NUMBER>214</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_SYST_RESEAUX</NAME>
+              <NUMBER>215</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_HD</NAME>
+              <NUMBER>22</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ZONE_PUBLIQUE</NAME>
+              <NUMBER>3</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RESEAU_DRRT-PUG</NAME>
+              <NUMBER>30</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE-TEST</NAME>
+              <NUMBER>3000</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-APPLI</NAME>
+              <NUMBER>3002</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-AGRIATE</NAME>
+              <NUMBER>3006</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>TEST-ETAB</NAME>
+              <NUMBER>3007</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO_RACINE_API</NAME>
+              <NUMBER>4</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VLAN401</NAME>
+              <NUMBER>401</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>wifi_recteur</NAME>
+              <NUMBER>402</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_ELGG</NAME>
+              <NUMBER>403</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ</NAME>
+              <NUMBER>5</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>AGRIATES</NAME>
+              <NUMBER>6</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ACCUEIL_ETABLISSEMENTS</NAME>
+              <NUMBER>7</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+          </VLANS>
         </PORT>
         <PORT>
           <AGGREGATE>
@@ -2073,6 +3645,218 @@
           <IFSTATUS>1</IFSTATUS>
           <IFTYPE>161</IFTYPE>
           <MAC>00:18:71:c1:e0:00</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>DEFAULT_VLAN</NAME>
+              <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VOIP_ASTERISK</NAME>
+              <NUMBER>13</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ227</NAME>
+              <NUMBER>14</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE_IP_RIHDA</NAME>
+              <NUMBER>149</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO-CSS</NAME>
+              <NUMBER>15</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RENATER</NAME>
+              <NUMBER>150</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA</NAME>
+              <NUMBER>152</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-VLAN-LIBRE</NAME>
+              <NUMBER>153</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-INTERCO-FOUNDRY</NAME>
+              <NUMBER>154</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ</NAME>
+              <NUMBER>155</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-Libre_Service</NAME>
+              <NUMBER>156</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-PEDA</NAME>
+              <NUMBER>157</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA2</NAME>
+              <NUMBER>158</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-PUG-DRRT</NAME>
+              <NUMBER>159</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVEUR-CSS</NAME>
+              <NUMBER>16</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ToIP_RIHDA</NAME>
+              <NUMBER>160</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>LIBR_SERVICE</NAME>
+              <NUMBER>162</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTER_EQUANT_RECTORAT</NAME>
+              <NUMBER>17</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_RIHDA</NAME>
+              <NUMBER>170</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_POLY</NAME>
+              <NUMBER>171</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_CEPE</NAME>
+              <NUMBER>172</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INT_EQUANT_ETABLISSEMENTS</NAME>
+              <NUMBER>18</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>video_RIHDA</NAME>
+              <NUMBER>180</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>postesIP_RIHDA</NAME>
+              <NUMBER>190</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ADMIN_RESEAU</NAME>
+              <NUMBER>196</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVERS</NAME>
+              <NUMBER>2</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>PERIPHERIQUES</NAME>
+              <NUMBER>201</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_NVEAU_BAT</NAME>
+              <NUMBER>202</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_FORMATION</NAME>
+              <NUMBER>204</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_CATI</NAME>
+              <NUMBER>205</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_INVITES</NAME>
+              <NUMBER>214</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_SYST_RESEAUX</NAME>
+              <NUMBER>215</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_HD</NAME>
+              <NUMBER>22</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ZONE_PUBLIQUE</NAME>
+              <NUMBER>3</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RESEAU_DRRT-PUG</NAME>
+              <NUMBER>30</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO_RACINE_API</NAME>
+              <NUMBER>4</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VLAN401</NAME>
+              <NUMBER>401</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>wifi_recteur</NAME>
+              <NUMBER>402</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_ELGG</NAME>
+              <NUMBER>403</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ</NAME>
+              <NUMBER>5</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>AGRIATES</NAME>
+              <NUMBER>6</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ACCUEIL_ETABLISSEMENTS</NAME>
+              <NUMBER>7</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+          </VLANS>
         </PORT>
         <PORT>
           <AGGREGATE>
@@ -2116,6 +3900,218 @@
           <IFSTATUS>1</IFSTATUS>
           <IFTYPE>161</IFTYPE>
           <MAC>00:18:71:c1:e0:00</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>DEFAULT_VLAN</NAME>
+              <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VOIP_ASTERISK</NAME>
+              <NUMBER>13</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ227</NAME>
+              <NUMBER>14</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE_IP_RIHDA</NAME>
+              <NUMBER>149</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO-CSS</NAME>
+              <NUMBER>15</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RENATER</NAME>
+              <NUMBER>150</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA</NAME>
+              <NUMBER>152</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-VLAN-LIBRE</NAME>
+              <NUMBER>153</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-INTERCO-FOUNDRY</NAME>
+              <NUMBER>154</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ</NAME>
+              <NUMBER>155</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-Libre_Service</NAME>
+              <NUMBER>156</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-PEDA</NAME>
+              <NUMBER>157</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA2</NAME>
+              <NUMBER>158</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-PUG-DRRT</NAME>
+              <NUMBER>159</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVEUR-CSS</NAME>
+              <NUMBER>16</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ToIP_RIHDA</NAME>
+              <NUMBER>160</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>LIBR_SERVICE</NAME>
+              <NUMBER>162</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTER_EQUANT_RECTORAT</NAME>
+              <NUMBER>17</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_RIHDA</NAME>
+              <NUMBER>170</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_POLY</NAME>
+              <NUMBER>171</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_CEPE</NAME>
+              <NUMBER>172</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INT_EQUANT_ETABLISSEMENTS</NAME>
+              <NUMBER>18</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>video_RIHDA</NAME>
+              <NUMBER>180</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>postesIP_RIHDA</NAME>
+              <NUMBER>190</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ADMIN_RESEAU</NAME>
+              <NUMBER>196</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVERS</NAME>
+              <NUMBER>2</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>PERIPHERIQUES</NAME>
+              <NUMBER>201</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_NVEAU_BAT</NAME>
+              <NUMBER>202</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_FORMATION</NAME>
+              <NUMBER>204</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_CATI</NAME>
+              <NUMBER>205</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_INVITES</NAME>
+              <NUMBER>214</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_SYST_RESEAUX</NAME>
+              <NUMBER>215</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_HD</NAME>
+              <NUMBER>22</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ZONE_PUBLIQUE</NAME>
+              <NUMBER>3</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RESEAU_DRRT-PUG</NAME>
+              <NUMBER>30</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO_RACINE_API</NAME>
+              <NUMBER>4</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VLAN401</NAME>
+              <NUMBER>401</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>wifi_recteur</NAME>
+              <NUMBER>402</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_ELGG</NAME>
+              <NUMBER>403</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ</NAME>
+              <NUMBER>5</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>AGRIATES</NAME>
+              <NUMBER>6</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ACCUEIL_ETABLISSEMENTS</NAME>
+              <NUMBER>7</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+          </VLANS>
         </PORT>
         <PORT>
           <AGGREGATE>
@@ -2269,6 +4265,218 @@
           <IFSTATUS>1</IFSTATUS>
           <IFTYPE>161</IFTYPE>
           <MAC>00:18:71:c1:e0:00</MAC>
+          <VLANS>
+            <VLAN>
+              <NAME>DEFAULT_VLAN</NAME>
+              <NUMBER>1</NUMBER>
+              <TAGGED>0</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VOIP_ASTERISK</NAME>
+              <NUMBER>13</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ227</NAME>
+              <NUMBER>14</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>COLLECTE_IP_RIHDA</NAME>
+              <NUMBER>149</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO-CSS</NAME>
+              <NUMBER>15</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RENATER</NAME>
+              <NUMBER>150</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA</NAME>
+              <NUMBER>152</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-VLAN-LIBRE</NAME>
+              <NUMBER>153</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-INTERCO-FOUNDRY</NAME>
+              <NUMBER>154</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ</NAME>
+              <NUMBER>155</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-Libre_Service</NAME>
+              <NUMBER>156</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-PEDA</NAME>
+              <NUMBER>157</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-DMZ-INFRA2</NAME>
+              <NUMBER>158</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>FW-PUG-DRRT</NAME>
+              <NUMBER>159</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVEUR-CSS</NAME>
+              <NUMBER>16</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ToIP_RIHDA</NAME>
+              <NUMBER>160</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>LIBR_SERVICE</NAME>
+              <NUMBER>162</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTER_EQUANT_RECTORAT</NAME>
+              <NUMBER>17</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_RIHDA</NAME>
+              <NUMBER>170</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_POLY</NAME>
+              <NUMBER>171</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DATA_CEPE</NAME>
+              <NUMBER>172</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INT_EQUANT_ETABLISSEMENTS</NAME>
+              <NUMBER>18</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>video_RIHDA</NAME>
+              <NUMBER>180</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>postesIP_RIHDA</NAME>
+              <NUMBER>190</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ADMIN_RESEAU</NAME>
+              <NUMBER>196</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>SERVERS</NAME>
+              <NUMBER>2</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>PERIPHERIQUES</NAME>
+              <NUMBER>201</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_NVEAU_BAT</NAME>
+              <NUMBER>202</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_FORMATION</NAME>
+              <NUMBER>204</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_CATI</NAME>
+              <NUMBER>205</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_INVITES</NAME>
+              <NUMBER>214</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>UTIL_SYST_RESEAUX</NAME>
+              <NUMBER>215</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_HD</NAME>
+              <NUMBER>22</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ZONE_PUBLIQUE</NAME>
+              <NUMBER>3</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>RESEAU_DRRT-PUG</NAME>
+              <NUMBER>30</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>INTERCO_RACINE_API</NAME>
+              <NUMBER>4</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>VLAN401</NAME>
+              <NUMBER>401</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>wifi_recteur</NAME>
+              <NUMBER>402</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ_ELGG</NAME>
+              <NUMBER>403</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>DMZ</NAME>
+              <NUMBER>5</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>AGRIATES</NAME>
+              <NUMBER>6</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+            <VLAN>
+              <NAME>ACCUEIL_ETABLISSEMENTS</NAME>
+              <NUMBER>7</NUMBER>
+              <TAGGED>1</TAGGED>
+            </VLAN>
+          </VLANS>
         </PORT>
         <PORT>
           <IFALIAS>DEFAULT_VLAN</IFALIAS>
@@ -3978,7 +6186,7 @@
         </COMPONENT>
     </COMPONENTS>
     </DEVICE>
-    <MODULEVERSION>2.3.99</MODULEVERSION>
+    <MODULEVERSION>4.0</MODULEVERSION>
     <PROCESSNUMBER>1</PROCESSNUMBER>
   </CONTENT>
   <DEVICEID>beria-2012-08-02-20-50-16</DEVICEID>


### PR DESCRIPTION
Take in charge Vlan for switch HPE (and other switchs) with SNMP : 
dot1qVlanStaticName, dot1qVlanStaticRowStatus, dot1qVlanCurrentEgressPorts and dot1qVlanCurrentUntaggedPorts )
Add Information if the Vlan is Tagged or not.
https://github.com/fusioninventory/fusioninventory.github.io/pull/66
https://github.com/fusioninventory/fusioninventory-for-glpi/pull/2852