### PR TITLE
Revert "Fix FireWall Win32 Unintialized value in concatenation (#735)"

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Win32/Firewall.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Win32/Firewall.pm
@@ -105,7 +105,7 @@ sub _makeProfileAndConnectionsAssociation {
     return unless $DNSRegisteredAdapters;
 
     foreach my $interface (getInterfaces()) {
-        next if ($interface->{STATUS} ne 'Up') || !defined($interface->{GUID});
+        next if ($interface->{STATUS} ne 'Up');
 
         my $profile;
         my $domainSettings = defined($interface->{GUID}) ? $DNSRegisteredAdapters->{$interface->{GUID}.'/'} : undef;


### PR DESCRIPTION
This reverts commit 260f63051584db776a18d8a521a4f7b075129f9a.

Sorry, but when I read XP test t/tools/win32.t, there is not GUID, so my commit is wrong.

I see you modified L.111 by defined, So i Think revert will fix it.