### PR TITLE
Update OCS.pm

### DIFF
--- a/lib/FusionInventory/Agent/HTTP/Client/OCS.pm
+++ b/lib/FusionInventory/Agent/HTTP/Client/OCS.pm
@@ -62,7 +62,7 @@ sub send { ## no critic (ProhibitBuiltinHomonyms)
     my $request_content = $message->getContent();
     $logger->debug2($log_prefix . "sending message:\n $request_content");
 
-    $request_content = $self->_compress(encode('UTF-8', $request_content));
+    $request_content = $self->_compress( $request_content);
     if (!$request_content) {
         $logger->error($log_prefix . 'inflating problem');
         return;


### PR DESCRIPTION
Encode('UTF-8') makes the Traditional Chinese characters of the Package Name on Mac OS 10.14 broken after received by GLPI server.