### PR TITLE
Downed interfaces speed fix

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Networks.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Networks.pm
@@ -128,30 +128,32 @@ sub _getInterfaces {
             );
         }
 
-        if (-r "/sys/class/net/$interface->{DESCRIPTION}/speed") {
-            my $speed = getFirstLine(
-                file => "/sys/class/net/$interface->{DESCRIPTION}/speed"
-            );
-            $interface->{SPEED} = $speed if $speed;
-        }
-        # On older kernels, we should try ethtool system call for speed
-        if (!$interface->{SPEED}) {
-            $logger->debug("looking for interface speed from syscall:");
-            my $infos = getInterfacesInfosFromIoctl(
-                interface => $interface->{DESCRIPTION},
-                logger    => $logger
-            );
-            if ($infos->{SPEED}) {
-                $logger->debug_result(
-                    action => 'retrieving interface speed from syscall',
-                    data   => $infos->{SPEED}
+        if (defined($interface->{STATUS}) && $interface->{STATUS} eq 'Up') {
+            if (-r "/sys/class/net/$interface->{DESCRIPTION}/speed") {
+                my $speed = getFirstLine(
+                    file => "/sys/class/net/$interface->{DESCRIPTION}/speed"
                 );
-                $interface->{SPEED} = $infos->{SPEED};
-            } else {
-                $logger->debug_result(
-                    action => 'retrieving interface speed from syscall',
-                    status => 'syscall failed'
+                $interface->{SPEED} = $speed if $speed;
+            }
+            # On older kernels, we should try ethtool system call for speed
+            if (!$interface->{SPEED}) {
+                $logger->debug("looking for interface speed from syscall:");
+                my $infos = getInterfacesInfosFromIoctl(
+                    interface => $interface->{DESCRIPTION},
+                    logger    => $logger
                 );
+                if ($infos->{SPEED}) {
+                    $logger->debug_result(
+                        action => 'retrieving interface speed from syscall',
+                        data   => $infos->{SPEED}
+                    );
+                    $interface->{SPEED} = $infos->{SPEED};
+                } else {
+                    $logger->debug_result(
+                        action => 'retrieving interface speed from syscall',
+                        status => 'syscall failed'
+                    );
+                }
             }
         }
     }

--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Networks.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Networks.pm
@@ -155,6 +155,8 @@ sub _getInterfaces {
                     );
                 }
             }
+        } else {
+            $interface->{SPEED} = 0;
         }
     }
 

--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Networks.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Networks.pm
@@ -156,6 +156,8 @@ sub _getInterfaces {
                 }
             }
         } else {
+            # Report zero speed in case the interface went from up to down
+            # or the server has non-zero interface speed
             $interface->{SPEED} = 0;
         }
     }


### PR DESCRIPTION
`/sys/class/net/*/speed` don't report speed for downed interfaces, e.g.:
```
# cat /sys/class/net/eth1/operstate 
down
# cat /sys/class/net/eth1/speed 
cat: /sys/class/net/eth1/speed: Invalid argument
```
then the agent tries to get speed from `ioctl`, which reports non-zero and unrealistic values (at least for me)
