### PR TITLE
Inventory::Generic::Networks::iLO mod

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Generic/Networks/iLO.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Generic/Networks/iLO.pm
@@ -10,6 +10,8 @@ use English qw(-no_match_vars);
 use FusionInventory::Agent::Tools;
 use FusionInventory::Agent::Tools::Network;
 
+our $runMeIfTheseChecksFailed = ['FusionInventory::Agent::Task::Inventory::Generic::Ipmi::Lan'];
+
 sub isEnabled {
     return $OSNAME eq 'MSWin32' ?
         canRun("C:\\Program\ Files\\HP\\hponcfg\\hponcfg.exe") :


### PR DESCRIPTION
Disabled `FusionInventory::Agent::Task::Inventory::Generic::Networks::iLO` in favor of `FusionInventory::Agent::Task::Inventory::Generic::Ipmi::Lan`, which does the same thing but better.