### PR TITLE
kvm detection

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Qemu.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Qemu.pm
@@ -33,6 +33,8 @@ sub _parseProcessList {
             $values->{name} = $1 if !$values->{name};
         } elsif ($option =~ m/^name (\S+)/) {
             $values->{name} = $1;
+        } elsif ($option =~ m/^\/usr\/(s?)bin\/(\S+)/) {
+            $values->{vmtype} = $2;
         } elsif ($option =~ m/^m .*size=(\S+)/) {
             my ($mem) = split(/,/,$1);
             $values->{mem} = getCanonicalSize($mem);


### PR DESCRIPTION
Detects process running the VM instance (/usr/[s]bin/kvm for example, and puts whatever is after /usr/[s]bin/ in $values->{vmtype