### PR TITLE
getInfoFromSmartctl() to FusionInventory::Agent::Task::Inventory::Linux::Storages::_getDevices()

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
@@ -39,12 +39,14 @@ sub _getDevices {
 
     my $root   = $params{root};
 
-    my %map = (
-        'MODEL'        => [ \&_getHdparmInfo, \&getInfoFromSmartctl ],
+    my %sources = (
+        'DESCRIPTION'  => [ \&_getHdparmInfo, \&getInfoFromSmartctl ],
+        'DISKSIZE'     => [ \&_getHdparmInfo, \&getInfoFromSmartctl ],
+        'FIRMWARE'     => [ \&_getHdparmInfo, \&getInfoFromSmartctl ],
         'MANUFACTURER' => [ \&getInfoFromSmartctl ],
+        'MODEL'        => [ \&_getHdparmInfo, \&getInfoFromSmartctl ],
         'WWN'          => [ \&_getHdparmInfo ],
     );
-    $map{DISKSIZE} = $map{FIRMWARE} = $map{DESCRIPTION} = $map{MODEL};
 
     my @devices = _getDevicesBase(%params);
 
@@ -66,16 +68,16 @@ sub _getDevices {
         }
     }
 
-    # get missing fields using functions defined in %map
+    # get missing fields using functions defined in %sources
     for my $device (@devices) {
-        # the hash keys are function references from %map
+        # the hash keys are function references from %sources
         my %info;
 
-        for my $field (keys %map) {
+        for my $field (keys %sources) {
             next if defined $device->{$field}
                 && !($field eq 'MANUFACTURER' && $device->{$field} eq 'ATA');
 
-            for my $sub (@{$map{$field}}) {
+            for my $sub (@{$sources{$field}}) {
                 # get info once for each device
                 $info{$sub} = &$sub(device => '/dev/' . $device->{NAME}, %params) unless $info{$sub};
 

--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
@@ -71,7 +71,11 @@ sub _getDevices {
         my %info;
 
         OUTER: for my $field (keys %map) {
-            next unless (($field eq 'MANUFACTURER' && $device->{$field} eq 'ATA') ||
+            next unless (
+                ($field eq 'MANUFACTURER'
+                 && defined $device->{$field}
+                 && $device->{$field} eq 'ATA')
+                      ||
                 !$device->{$field}
             );
 

--- a/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Linux/Storages.pm
@@ -134,23 +134,12 @@ sub _getHdparmInfo {
         dump => $params{dump},
     );
 
-    my %map = (
-        'serial'    => 'SERIALNUMBER',
-        'firmware'  => 'FIRMWARE',
-        'size'      => 'DISKSIZE',
-        'transport' => 'DESCRIPTION',
-        'model'     => 'MODEL',
-        'wwn'       => 'WWN'
-    );
-
     my $hdparm = getHdparmInfo(
         device => $params{device},
         %params
     );
 
-    return {
-        map { defined $hdparm->{$_} ? ($map{$_} => $hdparm->{$_}) : () } keys %map
-    };
+    return $hdparm;
 }
 
 sub _getDevicesBase {

--- a/lib/FusionInventory/Agent/Task/Inventory/Win32/Storages.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Win32/Storages.pm
@@ -35,10 +35,9 @@ sub doInventory {
                 device => "/dev/hd" . chr(ord('a') + $1),
                 logger => $logger
             );
-            $storage->{MODEL}    = $info->{model}    if $info->{model};
-            $storage->{FIRMWARE} = $info->{firmware} if $info->{firmware};
-            $storage->{SERIAL}   = $info->{serial}   if $info->{serial};
-            $storage->{DISKSIZE} = $info->{size}     if $info->{size};
+            for my $k (qw(MODEL FIRMWARE SERIALNUMBER DISKSIZE)) {
+                $storage->{$k} = $info->{$k} if defined $info->{$k};
+            }
         }
 
         $inventory->addEntry(

--- a/lib/FusionInventory/Agent/Tools/Generic.pm
+++ b/lib/FusionInventory/Agent/Tools/Generic.pm
@@ -191,12 +191,12 @@ sub getHdparmInfo {
 
     my $info;
     while (my $line = <$handle>) {
-        $info->{model}     = $1 if $line =~ /Model Number:\s+(\w.+\w)/;
-        $info->{firmware}  = $1 if $line =~ /Firmware Revision:\s+(\w+)/;
-        $info->{serial}    = $1 if $line =~ /Serial Number:\s+(\w*)/;
-        $info->{size}      = $1 if $line =~ /1000:\s+(\d*)\sMBytes/;
-        $info->{transport} = $1 if $line =~ /Transport:.+(SCSI|SATA|USB)/;
-        $info->{wwn}       = $1 if $line =~ /WWN Device Identifier:\s+(\w+)/;
+        $info->{DESCRIPTION}  = $1 if $line =~ /Transport:.+(SCSI|SATA|USB)/;
+        $info->{DISKSIZE}     = $1 if $line =~ /1000:\s+(\d*)\sMBytes/;
+        $info->{FIRMWARE}     = $1 if $line =~ /Firmware Revision:\s+(\w+)/;
+        $info->{MODEL}        = $1 if $line =~ /Model Number:\s+(\w.+\w)/;
+        $info->{SERIALNUMBER} = $1 if $line =~ /Serial Number:\s+(\w*)/;
+        $info->{WWN}          = $1 if $line =~ /WWN Device Identifier:\s+(\w+)/;
     }
     close $handle;
 

--- a/lib/FusionInventory/Agent/Tools/Linux.pm
+++ b/lib/FusionInventory/Agent/Tools/Linux.pm
@@ -279,6 +279,10 @@ sub getDevicesFromProc {
                     'removable' : 'disk'
         };
 
+        # WWN
+        my $wwn = _getValueFromSysProc($logger, $name, 'wwid', $root, $dump);
+        $device->{WWN} = $wwn if $wwn =~ s/^naa\./wwn-/;
+
         # Support PCI or other bus case as description
         foreach my $subsystem ("device/subsystem","device/device/subsystem") {
             my $link = _readLinkFromSysFs("/sys/block/$name/$subsystem", $root, $dump);

--- a/lib/FusionInventory/Agent/Tools/Linux.pm
+++ b/lib/FusionInventory/Agent/Tools/Linux.pm
@@ -281,7 +281,7 @@ sub getDevicesFromProc {
 
         # WWN
         my $wwn = _getValueFromSysProc($logger, $name, 'wwid', $root, $dump);
-        $device->{WWN} = $wwn if $wwn =~ s/^naa\./wwn-/;
+        $device->{WWN} = $wwn if $wwn && $wwn =~ s/^naa\./wwn-/;
 
         # Support PCI or other bus case as description
         foreach my $subsystem ("device/subsystem","device/device/subsystem") {

--- a/t/agent/tools/generic.t
+++ b/t/agent/tools/generic.t
@@ -8798,23 +8798,23 @@ my %lspci_tests = (
 
 my %hdparm_tests = (
     linux1 => {
-        firmware  => 'CXM13D1Q',
-        model     => 'SAMSUNG SSD PM830 mSATA 256GB',
-        serial    => 'S0XPNYAD412339',
-        size      => '256060',
-        transport => 'SATA',
-        wwn       => '5002538043584d30'
+        FIRMWARE     => 'CXM13D1Q',
+        MODEL        => 'SAMSUNG SSD PM830 mSATA 256GB',
+        SERIALNUMBER => 'S0XPNYAD412339',
+        DISKSIZE     => '256060',
+        DESCRIPTION  => 'SATA',
+        WWN          => '5002538043584d30'
     },
     linux2 => {
-        serial    => '',
-        size      => '77309',
+        SERIALNUMBER => '',
+        DISKSIZE     => '77309',
     },
     linux3 => {
-        firmware  => 'GKAOAC5A',
-        model     => 'HITACHI HUA7210SASUN1.0T 0812G2959E',
-        serial    => 'GTE000PAJ2959E',
-        size      => '1000204',
-        wwn       => '5000cca216dd3a2d'
+        FIRMWARE     => 'GKAOAC5A',
+        MODEL        => 'HITACHI HUA7210SASUN1.0T 0812G2959E',
+        SERIALNUMBER => 'GTE000PAJ2959E',
+        DISKSIZE     => '1000204',
+        WWN          => '5000cca216dd3a2d'
     }
 );
 


### PR DESCRIPTION
I noticed `MANUFACTURER` being equal to `MODEL` in some cases and after some digging decided to do the subj.