### PR TITLE
Storages inventory improvements

### DIFF
--- a/lib/FusionInventory/Agent/Inventory.pm
+++ b/lib/FusionInventory/Agent/Inventory.pm
@@ -107,7 +107,7 @@ my %fields = (
 
 my %checks = (
     STORAGES => {
-        INTERFACE => qr/^(SCSI|HDC|IDE|USB|1394|Serial-ATA|SAS)$/
+        INTERFACE => qr/^(SCSI|HDC|IDE|USB|1394|Serial-ATA|SAS|SATA)$/
     },
     VIRTUALMACHINES => {
         STATUS => qr/^(running|blocked|idle|paused|shutdown|crashed|dying|off)$/

--- a/lib/FusionInventory/Agent/Tools/Generic.pm
+++ b/lib/FusionInventory/Agent/Tools/Generic.pm
@@ -191,11 +191,12 @@ sub getHdparmInfo {
 
     my $info;
     while (my $line = <$handle>) {
-        $info->{DESCRIPTION}  = $1 if $line =~ /Transport:.+(SCSI|SATA|USB)/;
+        $info->{DESCRIPTION}  = $1 if $line =~ /Transport:.+(SATA|SAS|SCSI|USB)/;
         $info->{DISKSIZE}     = $1 if $line =~ /1000:\s+(\d*)\sMBytes/;
         $info->{FIRMWARE}     = $1 if $line =~ /Firmware Revision:\s+(\w+)/;
-        $info->{MODEL}        = $1 if $line =~ /Model Number:\s+(\w.+\w)/;
-        $info->{SERIALNUMBER} = $1 if $line =~ /Serial Number:\s+(\w*)/;
+        $info->{INTERFACE}    = $1 if $line =~ /Transport:.+(SATA|SAS|SCSI|USB)/;
+        $info->{MODEL}        = $1 if $line =~ /Model Number:\s+([\w\h\-\.]*\w)/;
+        $info->{SERIALNUMBER} = $1 if $line =~ /Serial Number:\s+([\w\h\-\.]*\w)/;
         $info->{WWN}          = $1 if $line =~ /WWN Device Identifier:\s+(\w+)/;
     }
     close $handle;

--- a/lib/FusionInventory/Agent/Tools/Generic.pm
+++ b/lib/FusionInventory/Agent/Tools/Generic.pm
@@ -189,11 +189,11 @@ sub getHdparmInfo {
     my $handle = getFileHandle(%params)
         or return;
 
-    my ($info, $abort);
+    my $info;
 
     while (my $line = <$handle>) {
         if ($line =~ /Integrity word not set/) {
-            $abort = 1;
+            $info = {};
             last;
         }
 
@@ -207,7 +207,7 @@ sub getHdparmInfo {
     }
     close $handle;
 
-    return $abort ? {} : $info;
+    return $info;
 }
 
 sub getPCIDevices {

--- a/lib/FusionInventory/Agent/Tools/Generic.pm
+++ b/lib/FusionInventory/Agent/Tools/Generic.pm
@@ -189,19 +189,25 @@ sub getHdparmInfo {
     my $handle = getFileHandle(%params)
         or return;
 
-    my $info;
+    my ($info, $abort);
+
     while (my $line = <$handle>) {
+        if ($line =~ /Integrity word not set/) {
+            $abort = 1;
+            last;
+        }
+
         $info->{DESCRIPTION}  = $1 if $line =~ /Transport:.+(SATA|SAS|SCSI|USB)/;
         $info->{DISKSIZE}     = $1 if $line =~ /1000:\s+(\d*)\sMBytes/;
         $info->{FIRMWARE}     = $1 if $line =~ /Firmware Revision:\s+(\w+)/;
         $info->{INTERFACE}    = $1 if $line =~ /Transport:.+(SATA|SAS|SCSI|USB)/;
-        $info->{MODEL}        = $1 if $line =~ /Model Number:\s+([\w\h\-\.]*\w)/;
-        $info->{SERIALNUMBER} = $1 if $line =~ /Serial Number:\s+([\w\h\-\.]*\w)/;
+        $info->{MODEL}        = $1 if $line =~ /Model Number:\s+(\w.+\w)/;
+        $info->{SERIALNUMBER} = $1 if $line =~ /Serial Number:\s+(\w*)/;
         $info->{WWN}          = $1 if $line =~ /WWN Device Identifier:\s+(\w+)/;
     }
     close $handle;
 
-    return $info;
+    return $abort ? {} : $info;
 }
 
 sub getPCIDevices {

--- a/lib/FusionInventory/Agent/Tools/Linux.pm
+++ b/lib/FusionInventory/Agent/Tools/Linux.pm
@@ -465,7 +465,7 @@ sub getInfoFromSmartctl {
         WWN => {
             src  => ['lu wwn device id'],
             # remove whitespaces
-            func => sub { return shift =~ s/\s+//gr },
+            func => sub { shift =~ s/\s+//gr },
         }
     };
 

--- a/lib/FusionInventory/Agent/Tools/Linux.pm
+++ b/lib/FusionInventory/Agent/Tools/Linux.pm
@@ -436,6 +436,19 @@ sub getInfoFromSmartctl {
     };
 
     my $attrs = {
+        DESCRIPTION => {
+            src => ['transport protocol']
+        },
+        DISKSIZE => {
+            src  => ['user capacity'],
+            func => \&getCanonicalSize,
+        },
+        FIRMWARE => {
+            src => ['revision', 'firmware version']
+        },
+        INTERFACE => {
+            src => ['transport protocol', 'sata version is']
+        },
         MANUFACTURER => {
             src  => ['vendor', 'model family', 'add. product id', 'device model', 'product'],
             func => \&getCanonicalManufacturer,
@@ -443,21 +456,16 @@ sub getInfoFromSmartctl {
         MODEL => {
             src => ['product', 'device model', 'model family']
         },
-        FIRMWARE => {
-            src => ['revision', 'firmware version']
-        },
-        DISKSIZE => {
-            src  => ['user capacity'],
-            func => \&getCanonicalSize,
-        },
-        DESCRIPTION => {
-            src => ['transport protocol']
+        SERIALNUMBER => {
+            src => ['serial number']
         },
         TYPE => {
             src => ['device type']
         },
-        SERIALNUMBER => {
-            src => ['serial number']
+        WWN => {
+            src  => ['lu wwn device id'],
+            # remove whitespaces
+            func => sub { return shift =~ s/\s+//gr },
         }
     };
 
@@ -467,6 +475,7 @@ sub getInfoFromSmartctl {
         'user capacity'    => qr/([\d\.\,\s]+(?:\w+)?)/,
         'device model'     => qr/([\w\s\-]+)/,
         'firmware version' => qr/(\S+)/,
+        'lu wwn device id' => qr/((?:0x)?[[:xdigit:]\h]+)/,
     };
 
     my %smartctl;

--- a/resources/generic/hdparm/linux4
+++ b/resources/generic/hdparm/linux4
@@ -1,0 +1,86 @@
+
+/dev/sdb:
+
+ATA device, with non-removable media
+	Model Number:       gnhta llcotaoinlAolacitnor naego evfrol
+	Serial Number:      llcotaoi natlb esie 
+	Firmware Revision:  zre-oel
+	Media Serial Num:   LIPETA2H.. .-- -IFELAPHT>n 
+  itlt=eT<TI
+	Media Manufacturer: EL
+>  p erif=xD<RICE
+	Transport:          0x6e72; Revision: 0x6c65
+Standards:
+	Used: unknown (minor revision code 0x2065) 
+	Supported: 14 13 11 10 6 5 
+	Likely used: 14
+Configuration:
+	Logical		max	current
+	cylinders	29728	0
+	heads		25964	0
+	sectors/track	30054	0
+	--
+	LBA    user addressable sectors: 1953656691
+	Logical  Sector size:                   512 bytes
+	Physical Sector size:                262144 bytes
+	device size with M = 1024*1024:      953933 MBytes
+	device size with M = 1000*1000:     1000272 MBytes (1000 GB)
+	cache/buffer size  = unknown
+	Nominal Media Rotation Rate: 12590
+Capabilities:
+	LBA, IORDY(can be disabled)
+	Standby timer values: spec'd by Standard, with device specific minimum
+	R/W multiple sector transfer: Max = 119	Current = ?
+	Recommended acoustic management value: 102, current value: 99
+	DMA: *mdma0 *mdma2 *mdma5 (?)
+	PIO: unknown
+Commands/features:
+	Enabled	Supported:
+	    	SMART feature set
+	    	Power Management feature set
+	   *	Write cache
+	   *	Look-ahead
+	   *	SERVICE interrupt
+	    	DEVICE_RESET command
+	   *	WRITE_BUFFER command
+	   *	READ_BUFFER command
+	   *	NOP cmd
+	   *	Power-Up In Standby feature set
+	    	SET_MAX security extension
+	    	Automatic Acoustic Management feature set
+	   *	FLUSH_CACHE_EXT
+	   *	SMART error logging
+	    	SMART self-test
+	   *	Media serial number
+	    	Media Card Pass Through Command feature set
+	   *	General Purpose Logging feature set
+	   *	WRITE_{DMA|MULTIPLE}_FUA_EXT
+	    	URG for READ_STREAM[_DMA]_EXT
+	    	Command Completion Time Limit (CCTL)
+	   *	IDLE_IMMEDIATE with UNLOAD
+	   *	unknown 76[0]
+	   *	unknown 76[5]
+	   *	unknown 76[6]
+	   *	Phy event counters
+	   *	NCQ priority information
+	   *	unknown 76[13]
+	   *	unknown 76[14]
+	    	Non-Zero buffer offsets in DMA Setup FIS
+	   *	DMA Setup Auto-Activate optimization
+	    	Device-initiated interface power management
+	   *	Asynchronous notification (eg. media change)
+	   *	Software settings preservation
+	   *	unknown 78[13]
+	   *	READ BUFFER DMA command
+	   *	Long physical sector diagnostics
+	   *	Data Set Management TRIM supported (limit 26222 blocks)
+		Removable Media Status Notification feature set supported
+Security: 
+	Master password revision code = 28527
+		supported
+	not	enabled
+	not	locked
+		frozen
+	not	expired: security count
+		supported: enhanced erase
+Integrity word not set (found 0x5254, expected 0xe3a5)

--- a/resources/linux/smartctl/sample9
+++ b/resources/linux/smartctl/sample9
@@ -1,0 +1,14 @@
+smartctl 7.0 2018-12-30 r4883 [x86_64-linux-4.13.6-0.1-default] (SUSE RPM)
+Copyright (C) 2002-18, Bruce Allen, Christian Franke, www.smartmontools.org
+
+=== START OF INFORMATION SECTION ===
+Vendor:               hp
+Product:              DVD A  DS8A5LH
+Revision:             1HE3
+Compliance:           SPC-3
+User Capacity:        7,757,100,351,738,617,888 bytes [7757 PB]
+Logical block size:   1752178720 bytes
+Device type:          CD/DVD
+Local Time is:        Sun Oct 18 23:47:59 2020 UTC
+NO MEDIUM present in device
+A mandatory SMART command failed: exiting. To continue, add one or more '-T permissive' options.

--- a/t/agent/tools/generic.t
+++ b/t/agent/tools/generic.t
@@ -8803,10 +8803,10 @@ my %hdparm_tests = (
         SERIALNUMBER => 'S0XPNYAD412339',
         DISKSIZE     => '256060',
         DESCRIPTION  => 'SATA',
+        INTERFACE    => 'SATA',
         WWN          => '5002538043584d30'
     },
     linux2 => {
-        SERIALNUMBER => '',
         DISKSIZE     => '77309',
     },
     linux3 => {

--- a/t/agent/tools/generic.t
+++ b/t/agent/tools/generic.t
@@ -8806,16 +8806,15 @@ my %hdparm_tests = (
         INTERFACE    => 'SATA',
         WWN          => '5002538043584d30'
     },
-    linux2 => {
-        DISKSIZE     => '77309',
-    },
+    linux2 => {},
     linux3 => {
         FIRMWARE     => 'GKAOAC5A',
         MODEL        => 'HITACHI HUA7210SASUN1.0T 0812G2959E',
         SERIALNUMBER => 'GTE000PAJ2959E',
         DISKSIZE     => '1000204',
         WWN          => '5000cca216dd3a2d'
-    }
+    },
+    linux4 => {},
 );
 
 my %edid_vendor_tests = (

--- a/t/agent/tools/linux.t
+++ b/t/agent/tools/linux.t
@@ -585,6 +585,7 @@ my %smartctl_tests = (
         TYPE         => 'disk',
         DESCRIPTION  => 'SAS',
         SERIALNUMBER => '3LM0L0FJ00009733Y46W',
+        INTERFACE    => 'SAS',
     },
     sample4 => {
         TYPE         => 'enclosure',
@@ -597,7 +598,9 @@ my %smartctl_tests = (
         MANUFACTURER => 'Micron',
         FIRMWARE     => 'D1DF003',
         MODEL        => 'MTFDDAK480TDC',
-        SERIALNUMBER => '202028413FA9'
+        SERIALNUMBER => '202028413FA9',
+        INTERFACE    => 'SATA',
+        WWN          => '500a075128413fa9',
     },
     sample6 => {
         MANUFACTURER => 'Hewlett-Packard',
@@ -606,7 +609,8 @@ my %smartctl_tests = (
         MODEL        => 'EG0600FBDSR',
         DISKSIZE     => 600127,
         FIRMWARE     => 'HPD2',
-        TYPE         => 'disk'
+        TYPE         => 'disk',
+        INTERFACE    => 'SAS',
     },
     sample7 => {
         TYPE         => 'disk',
@@ -615,7 +619,8 @@ my %smartctl_tests = (
         SERIALNUMBER => 'D5G7WG8L',
         DESCRIPTION  => 'SAS',
         FIRMWARE     => 'NS07',
-        MANUFACTURER => 'Hitachi'
+        MANUFACTURER => 'Hitachi',
+        INTERFACE    => 'SAS',
     },
     sample8 => {
         TYPE         => 'disk',
@@ -624,7 +629,17 @@ my %smartctl_tests = (
         SERIALNUMBER => 'A21WN061452000199',
         DESCRIPTION  => 'SATA',
         FIRMWARE     => '1.2',
-        MANUFACTURER => 'Indilinx'
+        MANUFACTURER => 'Indilinx',
+        INTERFACE    => 'SATA',
+        WWN          => '5e83a9710002cb71',
+    },
+    sample9 => {
+        TYPE         => 'CD',
+        DISKSIZE     => 7757100351738,
+        MODEL        => 'DVD',
+        FIRMWARE     => '1HE3',
+        DESCRIPTION  => 'SATA',
+        MANUFACTURER => 'Hewlett-Packard'
     },
 );
 


### PR DESCRIPTION
Some tweaks here and there:
* Retrieve `INTERFACE` field
* Added `SATA` to the valid `INTERFACE` values
* `getInfoFromSmartctl` retrieves `WWN` and `INTERFACE`
* `getInfoFromSmartctl` took "priority" over `getHdparmInfo` as the latter doesn't provide `MANUFACTURER` field
* Made `getHdparmInfo` regexps more strict as they sometimes still matched garbage output from `hdparm`, e.g.: `D$T$T;X`
* Forced `MODEL` retrieval as `/proc` may return incomplete data, e.g.:
```
$ cat /sys/block/sdx/device/model 
HGST HUS724020AL
$ smartctl -i /dev/sdx | grep Model:
Device Model:     HGST HUS724020ALA640
```
