### PR TITLE
Add a dash to allowed storage serial number chars for WD disks.

### DIFF
--- a/lib/FusionInventory/Agent/Tools/Generic.pm
+++ b/lib/FusionInventory/Agent/Tools/Generic.pm
@@ -210,7 +210,7 @@ sub getHdparmInfo {
         $info->{FIRMWARE}     = $1 if $line =~ /Firmware Revision:\s+(\w+)/;
         $info->{INTERFACE}    = $1 if $line =~ /Transport:.+(SATA|SAS|SCSI|USB)/;
         $info->{MODEL}        = $1 if $line =~ /Model Number:\s+(\w.+\w)/;
-        $info->{SERIALNUMBER} = $1 if $line =~ /Serial Number:\s+(\w*)/;
+        $info->{SERIALNUMBER} = $1 if $line =~ /Serial Number:\s+([\w-]*)/;
         $info->{WWN}          = $1 if $line =~ /WWN Device Identifier:\s+(\w+)/;
     }
     close $handle;


### PR DESCRIPTION
Western Digital drives have a dash in their serial numbers (e.g. WD-WX20A89H0316) . This means that all WD drives in the inventory have the same serial number - "WD". Which is unacceptable.

