### PR TITLE
Virtualization/LXC: use utsname instead of container name

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Lxc.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Lxc.pm
@@ -196,7 +196,8 @@ sub  _getVirtualMachines {
 
         my $uuid = getVirtualUUID($machineid, $hostname);
         $container->{UUID} = $uuid if $uuid;
-	$container->{NAME} = $container->{UTS_NAME} if $container->{UTS_NAME};
+        my $utsname = delete $container->{UTS_NAME};
+        $container->{NAME} = $utsname if $utsname && $container->{NAME} =~ /^\d+$/;
 
         push @machines, $container;
     }

--- a/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Lxc.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Virtualization/Lxc.pm
@@ -70,8 +70,10 @@ sub  _getVirtualMachine {
     if ($params{version} < 2.1) {
         # Before 2.1, we need to find MAC as lxc.network.hwaddr in config
         $command .= "; grep lxc.network.hwaddr $params{config}";
+        $command .= "; grep lxc.utsname $params{config}";
     } else {
         $command .= " -c lxc.net.0.hwaddr";
+        $command .= " -c lxc.uts.name";
     }
 
     my $handle = getFileHandle(
@@ -87,6 +89,10 @@ sub  _getVirtualMachine {
 
         my $key = $1;
         my $val = $2;
+        if ($key eq 'lxc.uts.name' || $key eq 'lxc.utsname') {
+            $container->{UTS_NAME} = $val;
+        }
+
         if ($key eq 'lxc.network.hwaddr' || $key eq 'lxc.net.0.hwaddr') {
             $container->{MAC} = lc($val)
                 if $val =~ $mac_address_pattern;
@@ -190,6 +196,7 @@ sub  _getVirtualMachines {
 
         my $uuid = getVirtualUUID($machineid, $hostname);
         $container->{UUID} = $uuid if $uuid;
+	$container->{NAME} = $container->{UTS_NAME} if $container->{UTS_NAME};
 
         push @machines, $container;
     }

--- a/t/tasks/inventory/virtualization/lxc.t
+++ b/t/tasks/inventory/virtualization/lxc.t
@@ -21,6 +21,7 @@ my %container_tests = (
         version => 2.0,
         result  => {
             NAME    => 'config',
+            UTS_NAME    => 'name1',
             VMTYPE  => 'lxc',
             STATUS  => STATUS_OFF,
             MEMORY  => '2048000',


### PR DESCRIPTION
This change responds to a problem with container name created in Proxmox.

In fact an ID is use in Promox to named LXC container.

For example:

```
lxc-ls -f
NAME STATE   AUTOSTART GROUPS IPV4         IPV6               UNPRIVILEGED 
100  RUNNING 0         -      XX.XX.XX.XX  XXXX:XXXX:XXX:XXXX false
101  RUNNING 0         -      XX.XX.XX.XX  XXXX:XXXX:XXX:XXXX false
106  RUNNING 0         -      XX.XX.XX.XX  XXXX:XXXX:XXX:XXXX false
108  RUNNING 0         -      XX.XX.XX.XX  XXXX:XXXX:XXX:XXXX false
113  RUNNING 0         -      XX.XX.XX.XX  XXXX:XXXX:XXX:XXXX false
```

With ID instead of hostname we are unable to know which server it is in GLPI.

Proxmox preserve utsname in containers configuration file so if you are ok I think we can used utsname parameter if it's exist instead of container name displayed in lxc-ls command.
